### PR TITLE
Fix runtime errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 
 USER root
 
-RUN apt-get update && apt-get -y install wget procps fonts-dejavu fontconfig
+RUN apt-get update && apt-get -y install wget procps fonts-dejavu fontconfig libgfortran5
 
 # install snap
 RUN wget http://step.esa.int/downloads/8.0/installers/esa-snap_sentinel_unix_8_0.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN sed -i -e 's/-Xmx1G/-Xmx32G/g' /usr/local/snap/bin/gpt.vmoptions
 WORKDIR /work
 RUN chmod 777 /work
 
+RUN useradd manfred
+USER manfred
+
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
 
 # set s3tbx readers to per-pixel geocoding


### PR DESCRIPTION
Fixing issues that occurred at runtime with the new SNAP 8.0.0 image:
- [x] Fix missing libgfortran
- [ ] Fix weird home directory paths #8 